### PR TITLE
Add test for SRM save/load 

### DIFF
--- a/tests/funcalign/test_srm.py
+++ b/tests/funcalign/test_srm.py
@@ -118,7 +118,7 @@ def test_can_instantiate():
     print("Test: different number of samples per subject")
 
     # Check save/load functionality for fitted SRM
-    srm_fn = '/Users/snastase/Work/srm-example.npz'
+    srm_fn = tmp_path
     s.save(srm_fn)
     s_load = brainiak.funcalign.srm.load(srm_fn)
     assert np.array_equal(s.s_, s_load.s_)

--- a/tests/funcalign/test_srm.py
+++ b/tests/funcalign/test_srm.py
@@ -15,7 +15,7 @@ from sklearn.exceptions import NotFittedError
 import pytest
 
 
-def test_can_instantiate():
+def test_can_instantiate(tmp_path):
     import brainiak.funcalign.srm
     s = brainiak.funcalign.srm.SRM()
     assert s, "Invalid SRM instance!"
@@ -118,9 +118,9 @@ def test_can_instantiate():
     print("Test: different number of samples per subject")
 
     # Check save/load functionality for fitted SRM
-    srm_fn = tmp_path
-    s.save(srm_fn)
-    s_load = brainiak.funcalign.srm.load(srm_fn)
+    srm_path = tmp_path / 'srm.npz'
+    s.save(srm_path)
+    s_load = brainiak.funcalign.srm.load(srm_path)
     assert np.array_equal(s.s_, s_load.s_)
     for w, wl in zip(s.w_, s_load.w_):
         assert np.array_equal(w, wl)

--- a/tests/funcalign/test_srm.py
+++ b/tests/funcalign/test_srm.py
@@ -117,6 +117,21 @@ def test_can_instantiate():
         s.fit(X)
     print("Test: different number of samples per subject")
 
+    # Check save/load functionality for fitted SRM
+    srm_fn = '/Users/snastase/Work/srm-example.npz'
+    s.save(srm_fn)
+    s_load = brainiak.funcalign.srm.load(srm_fn)
+    assert np.array_equal(s.s_, s_load.s_)
+    for w, wl in zip(s.w_, s_load.w_):
+        assert np.array_equal(w, wl)
+    assert np.array_equal(s.sigma_s_, s_load.sigma_s_)
+    assert np.array_equal(s.mu_, s_load.mu_)
+    assert np.array_equal(s.rho2_, s_load.rho2_)
+    assert s.features == s_load.features
+    assert s.n_iter == s_load.n_iter
+    assert s.rand_seed == s_load.rand_seed
+    print("Test: save/load functionality")
+
 
 def test_new_subject():
     import brainiak.funcalign.srm


### PR DESCRIPTION
I made a few minor adjustments to the wording and variable names in the save/load functions. I also added a simple test to `test_srm.py` that saves a fitted SRM object to `tmp_path` and reloads it and verifies the attributes against the original. Can someone check that I'm using `tmp_path` properly? As far as I understand, this `save` implementation is limited to `brainiak.funcalign.srm.SRM`—but it would be nice to extend this to the other SRM implementations. Might require a more flexible way to aggregate the variable attributes of different SRM implementations.